### PR TITLE
Fixed bugs in bstg_flist_import()

### DIFF
--- a/src/lib/fembot.h
+++ b/src/lib/fembot.h
@@ -2,6 +2,8 @@
 #define __FEMBOT_H
 
 /*
+ * vim:ts=4:sw=4:expandtab
+ *
  * Copyright 2011 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -115,6 +117,7 @@ typedef struct bstg_flist_t {
     u_int32_t number;
     u_int32_t lower;
     u_int32_t upper;
+    u_int32_t saved;
 } bstg_flist_t;
 
 /* initialize the list */


### PR DESCRIPTION
This adventure started when I passed a string with newlines to `bstg_flist_import()`.  The newlines caused the parse to fail with no clues to stderr about what went wrong.

Bugs I fixed in `bstg_flist_import()`:
- added support for tabs and newlines in the input string
- treat empty strings `""` and `"   "` the same way -- both as an error
- use `warnx()` to print useful error messages
- removed a TODO -- fix the bug were you cannot call `bstg_flist_import()` more than once in the unit tests
- `prove` gives an warning (`You named your test '1'.  You shouldn't use numbers for your test names.`) if tests are named with just a number -- I rename tests named like `"1"`
